### PR TITLE
Use log count instead of real exec time to timeout

### DIFF
--- a/mirbft_test.go
+++ b/mirbft_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -71,7 +70,7 @@ var _ = Describe("Mirbft", func() {
 	})
 
 	It("delivers all requests", func() {
-		_, err := recording.DrainClients(5 * time.Second)
+		_, err := recording.DrainClients(50000)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -84,7 +83,7 @@ var _ = Describe("Mirbft", func() {
 		})
 
 		It("still delivers all requests", func() {
-			_, err := recording.DrainClients(5 * time.Second)
+			_, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -100,7 +99,7 @@ var _ = Describe("Mirbft", func() {
 		})
 
 		It("still delivers all requests", func() {
-			_, err := recording.DrainClients(1 * time.Second)
+			_, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -116,7 +115,7 @@ var _ = Describe("Mirbft", func() {
 		})
 
 		It("still delivers all requests", func() {
-			_, err := recording.DrainClients(1 * time.Second)
+			_, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -129,7 +128,7 @@ var _ = Describe("Mirbft", func() {
 		})
 
 		PIt("still delivers all requests", func() {
-			_, err := recording.DrainClients(5 * time.Second)
+			_, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -142,7 +141,7 @@ var _ = Describe("Mirbft", func() {
 		})
 
 		It("still delivers all requests", func() {
-			_, err := recording.DrainClients(10 * time.Second)
+			_, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -155,7 +154,7 @@ var _ = Describe("Mirbft", func() {
 		})
 
 		It("still delivers all requests", func() {
-			_, err := recording.DrainClients(5 * time.Second)
+			_, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/testengine/player_test.go
+++ b/testengine/player_test.go
@@ -2,7 +2,6 @@ package testengine_test
 
 import (
 	"bytes"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,7 +29,7 @@ var _ = Describe("Player", func() {
 		recording, err = recorder.Recording()
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = recording.DrainClients(10 * time.Second)
+		_, err = recording.DrainClients(50000)
 		Expect(err).NotTo(HaveOccurred())
 
 		serialized = &bytes.Buffer{}

--- a/testengine/recorder_test.go
+++ b/testengine/recorder_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -68,7 +67,7 @@ var _ = Describe("Recorder", func() {
 	})
 
 	It("Executes and produces a log", func() {
-		count, err := recording.DrainClients(10 * time.Second)
+		count, err := recording.DrainClients(50000)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(count).To(Equal(36305))
 
@@ -99,7 +98,7 @@ var _ = Describe("Recorder", func() {
 		})
 
 		It("still executes and produces a log", func() {
-			count, err := recording.DrainClients(10 * time.Second)
+			count, err := recording.DrainClients(50000)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(count).To(Equal(27))
 		})


### PR DESCRIPTION
Signed-off-by: Jay Guo <guojiannan1101@gmail.com>