### PR TITLE
Using client count instead of client IDs in mirbft.StandardInitialNetworkState

### DIFF
--- a/mirbft.go
+++ b/mirbft.go
@@ -121,8 +121,7 @@ func (cp *ClientProposer) Propose(ctx context.Context, requestData *pb.Request) 
 	}
 }
 
-// TODO, maybe get rid of the varargs and go with a simple count?
-func StandardInitialNetworkState(nodeCount int, clientIDs ...uint64) *pb.NetworkState {
+func StandardInitialNetworkState(nodeCount int, clientCount int) *pb.NetworkState {
 	nodes := []uint64{}
 	for i := 0; i < nodeCount; i++ {
 		nodes = append(nodes, uint64(i))
@@ -132,10 +131,10 @@ func StandardInitialNetworkState(nodeCount int, clientIDs ...uint64) *pb.Network
 	checkpointInterval := numberOfBuckets * 5
 	maxEpochLength := checkpointInterval * 10
 
-	clients := make([]*pb.NetworkState_Client, len(clientIDs))
-	for i, clientID := range clientIDs {
+	clients := make([]*pb.NetworkState_Client, clientCount)
+	for i := 0; i < clientCount; i++ {
 		clients[i] = &pb.NetworkState_Client{
-			Id:           clientID,
+			Id:           uint64(i),
 			Width:        100,
 			LowWatermark: 0,
 		}

--- a/mirbft.go
+++ b/mirbft.go
@@ -132,7 +132,7 @@ func StandardInitialNetworkState(nodeCount int, clientCount int) *pb.NetworkStat
 	maxEpochLength := checkpointInterval * 10
 
 	clients := make([]*pb.NetworkState_Client, clientCount)
-	for i := 0; i < clientCount; i++ {
+	for i := range clients {
 		clients[i] = &pb.NetworkState_Client{
 			Id:           uint64(i),
 			Width:        100,

--- a/stress_test.go
+++ b/stress_test.go
@@ -461,7 +461,7 @@ type NodeStatus struct {
 func CreateNetwork(testConfig *TestConfig, doneC <-chan struct{}) *Network {
 	transport := NewFakeTransport(testConfig.NodeCount)
 
-	networkState := mirbft.StandardInitialNetworkState(testConfig.NodeCount, 0)
+	networkState := mirbft.StandardInitialNetworkState(testConfig.NodeCount, 1)
 
 	if testConfig.BucketCount != 0 {
 		networkState.Config.NumberOfBuckets = int32(testConfig.BucketCount)

--- a/testengine/recorder.go
+++ b/testengine/recorder.go
@@ -657,22 +657,16 @@ func BasicRecorder(nodeCount, clientCount int, reqsPerClient uint64) *Recorder {
 		})
 	}
 
-	clientIDs := make([]uint64, clientCount)
-	for i := 0; i < clientCount; i++ {
-		clientIDs[i] = uint64(i)
-	}
-
-	networkState := mirbft.StandardInitialNetworkState(nodeCount, clientIDs...)
+	networkState := mirbft.StandardInitialNetworkState(nodeCount, clientCount)
 
 	clientConfigs := make([]*ClientConfig, clientCount)
-	for i := 0; i < clientCount; i++ {
+	for i, cl := range networkState.Clients {
 		clientConfigs[i] = &ClientConfig{
-			ID:          clientIDs[i],
+			ID:          cl.Id,
 			MaxInFlight: int(networkState.Config.CheckpointInterval / 2),
 			Total:       reqsPerClient,
 			TxLatency:   10,
 		}
-		clientIDs[i] = clientConfigs[i].ID
 	}
 
 	return &Recorder{


### PR DESCRIPTION
First simple TODO to test workflow.